### PR TITLE
mm: fix mempool split allocation bookkeeping

### DIFF
--- a/core/mm.c
+++ b/core/mm.c
@@ -880,6 +880,7 @@ found:
 		qq->off = q->off;
 		qq->len = len;
 		q->off += len;
+		q->len -= len;
 		LIST1_ADD (p->alloc, qq);
 		r = &p->p[qq->off];
 	}


### PR DESCRIPTION
Update the remaining free chunk length when mempool_allocmem() splits an allocation. Without shrinking the original free entry after advancing its offset, the free list keeps stale length information and may hand out overlapping memory ranges.